### PR TITLE
Reduce animation loading boilerplate.

### DIFF
--- a/lib/components/chicken.dart
+++ b/lib/components/chicken.dart
@@ -9,7 +9,7 @@ import 'package:pixel_adventure/pixel_adventure.dart';
 
 enum State { idle, run, hit }
 
-class Chicken extends SpriteAnimationGroupComponent
+class Chicken extends SpriteAnimationGroupComponent<State>
     with HasGameRef<PixelAdventure>, CollisionCallbacks {
   final double offNeg;
   final double offPos;
@@ -34,9 +34,6 @@ class Chicken extends SpriteAnimationGroupComponent
   bool gotStomped = false;
 
   late final Player player;
-  late final SpriteAnimation _idleAnimation;
-  late final SpriteAnimation _runAnimation;
-  late final SpriteAnimation _hitAnimation;
 
   @override
   FutureOr<void> onLoad() {
@@ -65,14 +62,10 @@ class Chicken extends SpriteAnimationGroupComponent
   }
 
   void _loadAllAnimations() {
-    _idleAnimation = _spriteAnimation('Idle', 13);
-    _runAnimation = _spriteAnimation('Run', 14);
-    _hitAnimation = _spriteAnimation('Hit', 15)..loop = false;
-
     animations = {
-      State.idle: _idleAnimation,
-      State.run: _runAnimation,
-      State.hit: _hitAnimation,
+      State.idle: _spriteAnimation('Idle', 13),
+      State.run: _spriteAnimation('Run', 14),
+      State.hit: _spriteAnimation('Hit', 15)..loop = false,
     };
 
     current = State.idle;

--- a/lib/components/player.dart
+++ b/lib/components/player.dart
@@ -23,7 +23,7 @@ enum PlayerState {
   disappearing
 }
 
-class Player extends SpriteAnimationGroupComponent
+class Player extends SpriteAnimationGroupComponent<PlayerState>
     with HasGameRef<PixelAdventure>, KeyboardHandler, CollisionCallbacks {
   String character;
   Player({
@@ -32,13 +32,6 @@ class Player extends SpriteAnimationGroupComponent
   }) : super(position: position);
 
   final double stepTime = 0.05;
-  late final SpriteAnimation idleAnimation;
-  late final SpriteAnimation runningAnimation;
-  late final SpriteAnimation jumpingAnimation;
-  late final SpriteAnimation fallingAnimation;
-  late final SpriteAnimation hitAnimation;
-  late final SpriteAnimation appearingAnimation;
-  late final SpriteAnimation disappearingAnimation;
 
   final double _gravity = 9.8;
   final double _jumpForce = 260;
@@ -123,23 +116,15 @@ class Player extends SpriteAnimationGroupComponent
   }
 
   void _loadAllAnimations() {
-    idleAnimation = _spriteAnimation('Idle', 11);
-    runningAnimation = _spriteAnimation('Run', 12);
-    jumpingAnimation = _spriteAnimation('Jump', 1);
-    fallingAnimation = _spriteAnimation('Fall', 1);
-    hitAnimation = _spriteAnimation('Hit', 7)..loop = false;
-    appearingAnimation = _specialSpriteAnimation('Appearing', 7);
-    disappearingAnimation = _specialSpriteAnimation('Desappearing', 7);
-
     // List of all animations
     animations = {
-      PlayerState.idle: idleAnimation,
-      PlayerState.running: runningAnimation,
-      PlayerState.jumping: jumpingAnimation,
-      PlayerState.falling: fallingAnimation,
-      PlayerState.hit: hitAnimation,
-      PlayerState.appearing: appearingAnimation,
-      PlayerState.disappearing: disappearingAnimation,
+      PlayerState.idle: _spriteAnimation('Idle', 11),
+      PlayerState.running: _spriteAnimation('Run', 12),
+      PlayerState.jumping: _spriteAnimation('Jump', 1),
+      PlayerState.falling: _spriteAnimation('Fall', 1),
+      PlayerState.hit: _spriteAnimation('Hit', 7)..loop = false,
+      PlayerState.appearing: _specialSpriteAnimation('Appearing', 7),
+      PlayerState.disappearing: _specialSpriteAnimation('Desappearing', 7),
     };
 
     // Set current animation


### PR DESCRIPTION
Thanks again for the great series. I noticed that there was a lot of unnecessary boilerplate used to load the animations for the Player and Chicken classes. This PR refactors this to remove the unused fields that stores the animations. As they are only ever referenced in the `animations` map, they are just cluttering up the class. If they are ever needed for something else in the future, they can be pulled from the `animations` map.

In addition it is a good practice to declare the type you are using to specify the animations in the map:

```dart
class Player extends SpriteAnimationGroupComponent<PlayerState>
```

That way the compiler can help you with warnings if you try to use something other than a `PlayerState` for `current`.
