### PR TITLE
Executing Initial async callbacks all at once

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,8 +6,7 @@ import 'package:pixel_adventure/pixel_adventure.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Flame.device.fullScreen();
-  await Flame.device.setLandscape();
+  await Future.wait([Flame.device.fullScreen(), Flame.device.setLandscape()]);
 
   PixelAdventure game = PixelAdventure();
   runApp(


### PR DESCRIPTION
Instead of awaiting full screen and landscape call backs one by one, we can use Future.wait to wait all at once.